### PR TITLE
Removed legacy vsftpd option

### DIFF
--- a/extra/vsftpd.conf
+++ b/extra/vsftpd.conf
@@ -2,7 +2,7 @@
 anonymous_enable=NO
 # Allow 'local' users with WRITE permissions (0755)
 #local_enable=YES
-#write_enable=YES
+write_enable=YES
 local_umask=022
 dirmessage_enable=YES
 xferlog_enable=YES

--- a/extra/vsftpd.conf
+++ b/extra/vsftpd.conf
@@ -1,8 +1,8 @@
 # No ANONYMOUS users allowed
 anonymous_enable=NO
 # Allow 'local' users with WRITE permissions (0755)
-local_enable=YES
-write_enable=YES
+#local_enable=YES
+#write_enable=YES
 local_umask=022
 dirmessage_enable=YES
 xferlog_enable=YES


### PR DESCRIPTION
Previously, the v1 FTP management system used an insecure method of authenticating users. This has been since migrated.