### PR TITLE
Log PDOException message using error_log() instead of printing to the user.

### DIFF
--- a/web/include/db.php
+++ b/web/include/db.php
@@ -12,7 +12,8 @@ try{
         $conn = new PDO("mysql:host=$server;dbname=$database", $username, $password);
 
 }catch(PDOException $e){
-        die("Connection failed: " . $e->getMessage());
+        error_log('Database connection failed: ' . $e->getMessage());
+        die('Connection failed. See error_log for details.');
 }
 
 ?>


### PR DESCRIPTION
PDOException message can contain credentials.
For example: Access denied for user 'root'@'localhost' (using password: YES)

You should log message (if you want) instead of printing to the user.